### PR TITLE
Reduce vendor.js footprint

### DIFF
--- a/src/lib/CodeHighlight.jsx
+++ b/src/lib/CodeHighlight.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/common';
 import 'highlight.js/styles/github.css';
 
 class CodeHighlight extends Component {


### PR DESCRIPTION
Closes #9

highlight.js is currently used with all its supported languages, taking a large amount of space.
Only the most common languages are loaded with this PR, which are, in the currently used version:
```
xml
bash
c
cpp
csharp
css
markdown
diff
ruby
go
graphql
ini
java
javascript
json
kotlin
less
lua
makefile
perl
objectivec
php
php-template
plaintext
python
python-repl
r
rust
scss
shell
sql
swift
yaml
typescript
vbnet
wasm
```

Details are in the issue.